### PR TITLE
I thought I'd try the naïve big endian swap and see what happened

### DIFF
--- a/src/ChecksumChallenge/Checksum/Junior2.cs
+++ b/src/ChecksumChallenge/Checksum/Junior2.cs
@@ -18,10 +18,10 @@ internal partial class Checksum
         {
             switch (i % 4)
             {
-                case 0: sum += arr[i] << 24; break;
-                case 1: sum += arr[i] << 16; break;
-                case 2: sum += arr[i] <<  8; break;
-                case 3: sum += arr[i] <<  0; break;
+                case 0: sum += (uint)(arr[i] << 24); break;
+                case 1: sum += (uint)(arr[i] << 16); break;
+                case 2: sum += (uint)(arr[i] <<  8); break;
+                case 3: sum += (uint)(arr[i] <<  0); break;
             }
         }
 

--- a/src/ChecksumChallenge/Checksum/Junior2.cs
+++ b/src/ChecksumChallenge/Checksum/Junior2.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ChecksumChallenge;
+
+internal partial class Checksum
+{
+    public static uint ChecksumJunior2(ReadOnlySpan<byte> arr)
+    {
+        if (arr.Length == 0) return 0;
+
+        uint sum = 0;
+
+        for (var i = 0; i < arr.Length; i++)
+        {
+            switch (i % 4)
+            {
+                case 0: sum += arr[i] << 24; break;
+                case 1: sum += arr[i] << 16; break;
+                case 2: sum += arr[i] <<  8; break;
+                case 3: sum += arr[i] <<  0; break;
+            }
+        }
+
+        return sum;
+    }
+}

--- a/src/ChecksumChallenge/Checksum/Pro2.cs
+++ b/src/ChecksumChallenge/Checksum/Pro2.cs
@@ -16,17 +16,17 @@ internal partial class Checksum
         var i = 0;
         for (i = 0; i <= arr.Length - 4; i+=4)
         {
-            sum += (arr[i] << 24) + (arr[i+1] << 16) + (arr[i+2] << 8) + (arr[i+3]);
+            sum += (uint)(arr[i] << 24) + (uint)(arr[i+1] << 16) + (uint)(arr[i+2] << 8) + (uint)(arr[i+3]);
         }
 
         for (; i < arr.Length; i++)
         {
             switch (i % 4)
             {
-                case 0: sum += arr[i] << 24; break;
-                case 1: sum += arr[i] << 16; break;
-                case 2: sum += arr[i] <<  8; break;
-                case 3: sum += arr[i] <<  0; break;
+                case 0: sum += (uint)(arr[i] << 24); break;
+                case 1: sum += (uint)(arr[i] << 16); break;
+                case 2: sum += (uint)(arr[i] <<  8); break;
+                case 3: sum += (uint)(arr[i] <<  0); break;
             }
         }
 

--- a/src/ChecksumChallenge/Checksum/Pro2.cs
+++ b/src/ChecksumChallenge/Checksum/Pro2.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ChecksumChallenge;
+
+internal partial class Checksum
+{
+    public static uint ChecksumPro2(ReadOnlySpan<byte> arr)
+    {
+        if (arr.Length == 0) return 0;
+
+        uint sum = 0;
+        var i = 0;
+        for (i = 0; i <= arr.Length - 4; i+=4)
+        {
+            sum += (arr[i] << 24) + (arr[i+1] << 16) + (arr[i+2] << 8) + (arr[i+3]);
+        }
+
+        for (; i < arr.Length; i++)
+        {
+            switch (i % 4)
+            {
+                case 0: sum += arr[i] << 24; break;
+                case 1: sum += arr[i] << 16; break;
+                case 2: sum += arr[i] <<  8; break;
+                case 3: sum += arr[i] <<  0; break;
+            }
+        }
+
+        return sum;
+    }
+}

--- a/src/ChecksumChallenge/Program.cs
+++ b/src/ChecksumChallenge/Program.cs
@@ -63,7 +63,17 @@ public class Program
             return Checksum.ChecksumExpertAvx2(SourceBytes);
         }
 
-        
+        [Benchmark]
+        public uint Junior2()
+        {
+            return Checksum.ChecksumJunior2(SourceBytes);
+        }
+
+        [Benchmark]
+        public uint Pro2()
+        {
+            return Checksum.ChecksumPro2(SourceBytes);
+        }
     }
 
     public static void Assertions()
@@ -83,6 +93,8 @@ public class Program
             Assert.Equal(crc, Checksum.ChecksumExpert(span));
             Assert.Equal(crc, Checksum.ChecksumExpertAvx(span));
             Assert.Equal(crc, Checksum.ChecksumExpertAvx2(span));
+            Assert.Equal(crc, Checksum.ChecksumJunior2(span));
+            Assert.Equal(crc, Checksum.ChecksumPro2(span));
         }
         
     }


### PR DESCRIPTION
Junior2 uses the switch like Junior but accumulates into a single sum by endian-correcting the bytes as it goes. It's slower than Junior.
Pro2 naïvely endian corrects 4 bytes at a time and sums those. It's slower than Pro, but doesn't have manual unwinding to 16 bytes at a time like Pro (only 4 bytes at a time as required for the endian swap) so it's actually surprising it's so close considering the code size is _dramatically_ smaller.

|     Method |  Length |        Mean | Ratio | Code Size |
|----------- |-------- |------------:|------:|----------:|
|     Junior | 1000000 | 1,828.97 us | 1.000 |     231 B |
|        Pro | 1000000 |   306.59 us | 0.168 |     843 B |
|    Junior2 | 1000000 | 1,903.93 us | 1.041 |     225 B |
|       Pro2 | 1000000 |   328.81 us | 0.180 |     353 B |

Incidentally, what's the error you mention in the article, is it the end limit test being too complex?
> Pro made a mistake that, if fixed, would cause the JIT compiler to remove the bound checks and bring its performance closer to Senior’s without using pointers. I encourage you to spot it.